### PR TITLE
Change loading screen wording

### DIFF
--- a/frontend/src/components/Alert/index.module.css
+++ b/frontend/src/components/Alert/index.module.css
@@ -8,7 +8,7 @@
   }
 
   p {
-    max-width: 335px;
+    max-width: 500px;
     font-size: 14px;
     font-weight: 400;
     line-height: 120%;

--- a/frontend/src/pages/HomePage/index.tsx
+++ b/frontend/src/pages/HomePage/index.tsx
@@ -104,7 +104,7 @@ export const HomePage: FC = () => {
     <>
       {pageStatus === 'loading' && (
         <Alert type="loading" actions={<span>Submitting vote...</span>}>
-          Once you confirm this vote you will not be able to cancel it.
+          Your vote is always private, and can be changed until the poll closes.
         </Alert>
       )}
       {pageStatus === 'error' && error && (


### PR DESCRIPTION
- increase max-width on Alert message, so it fits on one line

## Resources
![Screenshot_14-3-2024_95648_localhost](https://github.com/oasisprotocol/dapp-voting/assets/9722540/f54061ce-0228-4a7d-a383-5f0e44050540)
