### PR TITLE
Fix network switch bug

### DIFF
--- a/frontend/src/providers/Web3Provider.tsx
+++ b/frontend/src/providers/Web3Provider.tsx
@@ -89,7 +89,7 @@ export const Web3ContextProvider: FC<PropsWithChildren> = ({ children }) => {
       throw new Error('[Web3Context] Sapphire provider is required!')
     }
 
-    if (!CHAINS.has(chainId)) {
+    if (!CHAINS.has(chainId) || VITE_NETWORK !== chainId) {
       throw new UnknownNetworkError('Unknown network!')
     }
 


### PR DESCRIPTION
## Description

This PR fixes network switch bug. Issue was that if either Sapphire testnet or Sapphire mainnet were selected in the provider, it would not detect it as wrong network, since testnet was added to `CHAINS` config. Due to check missing, if the current `VITE_NETWORK` does not match the current provider network. 