### PR TITLE
Auto request accounts after switching network

### DIFF
--- a/frontend/src/components/ConnectWallet/index.tsx
+++ b/frontend/src/components/ConnectWallet/index.tsx
@@ -40,18 +40,6 @@ export const ConnectWallet: FC<Props> = ({ mobileSticky }) => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
-  const handleSwitchNetwork = async () => {
-    setIsLoading(true)
-    try {
-      await switchNetwork()
-      setIsUnknownNetwork(false)
-    } catch (ex) {
-      setAppError(ex as Error)
-    } finally {
-      setIsLoading(false)
-    }
-  }
-
   const handleConnectWallet = async () => {
     setIsLoading(true)
     try {
@@ -62,6 +50,19 @@ export const ConnectWallet: FC<Props> = ({ mobileSticky }) => {
       } else {
         setAppError(ex as Error)
       }
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  const handleSwitchNetwork = async () => {
+    setIsLoading(true)
+    try {
+      await switchNetwork()
+      setIsUnknownNetwork(false)
+      handleConnectWallet()
+    } catch (ex) {
+      setAppError(ex as Error)
     } finally {
       setIsLoading(false)
     }

--- a/frontend/src/providers/Web3Provider.tsx
+++ b/frontend/src/providers/Web3Provider.tsx
@@ -110,8 +110,11 @@ export const Web3ContextProvider: FC<PropsWithChildren> = ({ children }) => {
 
   const _chainChanged = useCallback(() => {
     // TODO: Integrate seamlessly, so that page reload is not needed
-    window.location.reload()
-  }, [])
+
+    if (state.isConnected) {
+      window.location.reload()
+    }
+  }, [state.isConnected])
 
   const _connect = useCallback(() => _connectionChanged(true), [])
   const _disconnect = useCallback(() => _connectionChanged(false), [])


### PR DESCRIPTION
## Description

The issue reported was, that after user switches the network(to the correct network provided by `VITE_NETWORK`), the user will still need to request accounts by clicking "Connect Wallet". This PR does this automatically, by calling connect wallet right after network change.

Resolves https://github.com/oasisprotocol/dapp-voting/issues/51

## Resources 

https://www.loom.com/share/3eaa0d4538c14f0e9d14d7c115448952