### PR TITLE
Improve error handling

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -14,6 +14,6 @@ module.exports = {
   plugins: ['react-refresh'],
   rules: {
     'react-refresh/only-export-components': ['warn', { allowConstantExport: true }],
-    indent: ['error', 2],
+    indent: ['error', 2, { SwitchCase: 1 }],
   },
 }

--- a/frontend/src/components/ErrorBoundaryLayout/index.tsx
+++ b/frontend/src/components/ErrorBoundaryLayout/index.tsx
@@ -3,6 +3,7 @@ import { LayoutBase } from '../LayoutBase'
 import { StringUtils } from '../../utils/string.utils.ts'
 import { Alert } from '../Alert'
 import classes from './index.module.css'
+import { toErrorString } from '../../utils/errors.ts'
 
 interface Props {
   error: unknown
@@ -11,7 +12,7 @@ interface Props {
 export const ErrorBoundaryLayout: FC<Props> = ({ error }) => (
   <LayoutBase>
     <Alert className={classes.errorAlert} type="error">
-      {StringUtils.truncate((error as Error).message ?? JSON.stringify(error))}
+      {StringUtils.truncate(toErrorString(error as Error))}
     </Alert>
   </LayoutBase>
 )

--- a/frontend/src/pages/ResultsPage/index.tsx
+++ b/frontend/src/pages/ResultsPage/index.tsx
@@ -11,6 +11,7 @@ import { useAppState } from '../../hooks/useAppState.ts'
 import { DateUtils } from '../../utils/date.utils.ts'
 import { useWeb3 } from '../../hooks/useWeb3.ts'
 import { PollChoice } from '../../types'
+import { toErrorString } from '../../utils/errors.ts'
 
 interface PollChoiceWithValue extends PollChoice {
   value: bigint
@@ -25,6 +26,7 @@ export const ResultsPage: FC = () => {
   const { getVoteCounts } = useWeb3()
   const {
     state: { poll, isDesktopScreen, isMobileScreen },
+    setAppError,
   } = useAppState()
 
   const [voteCount, setVoteCount] = useState<bigint[]>([])
@@ -35,9 +37,13 @@ export const ResultsPage: FC = () => {
     let shouldUpdate = true
 
     const init = async () => {
-      const voteCountsResponse = await getVoteCounts()
-      if (shouldUpdate) {
-        setVoteCount(voteCountsResponse)
+      try {
+        const voteCountsResponse = (await getVoteCounts())!
+        if (shouldUpdate) {
+          setVoteCount(voteCountsResponse)
+        }
+      } catch (ex) {
+        setAppError(toErrorString(ex as Error))
       }
     }
 

--- a/frontend/src/providers/Web3Context.ts
+++ b/frontend/src/providers/Web3Context.ts
@@ -23,10 +23,10 @@ export interface Web3ProviderContext {
   getBalance: () => Promise<bigint>
   getTransaction: (txHash: string) => Promise<TransactionResponse | null>
   isProviderAvailable: () => Promise<boolean>
-  getPoll: () => Promise<DefaultReturnType<[Poll]>>
+  getPoll: () => Promise<DefaultReturnType<[Poll]> | void>
   canVoteOnPoll: () => Promise<boolean>
   vote: (choiceId: BigNumberish) => Promise<TransactionResponse | null>
-  getVoteCounts: () => Promise<bigint[]>
+  getVoteCounts: () => Promise<bigint[] | void>
 }
 
 export const Web3Context = createContext<Web3ProviderContext>({} as Web3ProviderContext)

--- a/frontend/src/utils/errors.ts
+++ b/frontend/src/utils/errors.ts
@@ -1,3 +1,7 @@
+import { CallExceptionError, EthersError } from 'ethers'
+
+const NETWORK_ERROR_MESSAGE = 'Unable to connect to RPC node! Please check your internet connection.'
+
 export class UnknownNetworkError extends Error {
   constructor(message: string) {
     super(message)
@@ -6,4 +10,55 @@ export class UnknownNetworkError extends Error {
 
 export interface EIP1193Error extends Error {
   code: number
+}
+
+export const handleKnownErrors = (error: Error): void => {
+  const errorMessage = (error?.message ?? '').toLowerCase()
+
+  switch (errorMessage) {
+    case 'failed to fetch':
+      throw new Error(NETWORK_ERROR_MESSAGE)
+  }
+}
+
+export const handleKnownContractCallExceptionErrors = <T = unknown>(
+  callExceptionError: CallExceptionError,
+  defaultReturn: Promise<T>
+) => {
+  const reason = callExceptionError?.reason ?? ''
+
+  switch (reason) {
+    // Contract call reverted
+    case 'require(false)': {
+      return defaultReturn
+    }
+  }
+}
+
+export const handleKnownEthersErrors = (error: EthersError) => {
+  const errorCode = error?.code ?? ''
+
+  switch (errorCode) {
+    case 'ACTION_REJECTED':
+      throw new Error('User rejected action, please try again.')
+    case 'NETWORK_ERROR':
+    case 'TIMEOUT':
+      throw new Error(NETWORK_ERROR_MESSAGE)
+  }
+  // Default to short message
+  throw new Error(error.shortMessage)
+}
+
+export const toErrorString = (error: Error = new Error('Unknown error')) => {
+  let errorString = ''
+
+  if (Object.prototype.hasOwnProperty.call(error, 'message')) {
+    errorString = (error as Error).message
+  } else if (typeof error === 'object') {
+    errorString = JSON.stringify(errorString)
+  } else {
+    errorString = error
+  }
+
+  return errorString
 }


### PR DESCRIPTION
Improve error handling(clearer message mostly) in the following cases:

- network errors (fetching poll & poll results), but since the provider keeps polling, I was unsure how to tests
- network error on fetch `canVote` query call
- clear distinction between `require(false)` contract rejection and network error on `canVote`
- most of other changes related to clearer messaging around errors

Changes made to `.eslintrc.cjs`, due to switch ident conflicts.