### PR TITLE
Center heading and badges

### DIFF
--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -21,4 +21,7 @@ fenced-code-language: false
 
 # Allow <details> and <section> HTML elements
 no-inline-html:
-  allowed_elements: ['details', 'summary', 'a', 'br', 'div', 'h2', 'p', 'strong']
+  allowed_elements: ['details', 'summary', 'a', 'br', 'div', 'h1', 'h2', 'p', 'strong', 'center']
+
+# Due to feature to link back to top
+first-line-h1: false

--- a/README.md
+++ b/README.md
@@ -1,9 +1,11 @@
-# Oasis voTEE
-
 <a name="readme-top"></a>
 
+<h1 align="center">Oasis voTEE</h1>
+
+<center>
 [![CI build status][github-ci-build-badge]][github-ci-build-link]
 [![CI lint status][github-ci-lint-badge]][github-ci-lint-link]
+</center>
 
 <!-- PROJECT BASIC INFORMATION -->
 <br />


### PR DESCRIPTION
- remove first-line-h1, so that readme-top feature works as expected