### PR TITLE
Split build bundle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ dist-ssr
 
 # eslint
 /.eslintcache
+
+# vite-bundle-visualizer output
+/frontend/stats.html

--- a/backend/package.json
+++ b/backend/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "@openzeppelin/contracts": "^4.9.5",
-    "ethers": "^6.11.1"
+    "ethers": "6.10.0"
   },
   "devDependencies": {
     "@nomicfoundation/hardhat-ethers": "^3.0.5",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -22,7 +22,7 @@
     "@oasisprotocol/dapp-voting-backend": "workspace:^",
     "@oasisprotocol/sapphire-paratime": "^1.3.2",
     "@phosphor-icons/core": "^2.0.8",
-    "ethers": "^6.11.1",
+    "ethers": "6.10.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-intersection-observer": "^9.8.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,7 +8,8 @@
     "checkTs": "tsc --noEmit",
     "dev": "vite",
     "build": "tsc && node ./internals/scripts/build.mjs",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "visualize:bundle": "npx vite-bundle-visualizer"
   },
   "packageManager": "pnpm@8.15.4",
   "engines": {
@@ -35,6 +36,7 @@
     "@types/react": "^18.2.56",
     "@types/react-dom": "^18.2.19",
     "@vitejs/plugin-react-swc": "^3.5.0",
+    "rollup-plugin-visualizer": "^5.12.0",
     "typescript": "^5.2.2",
     "vite": "^5.1.4",
     "vite-plugin-svgr": "^4.2.0"

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,8 +1,9 @@
-import { defineConfig } from 'vite'
+import { defineConfig, PluginOption, splitVendorChunkPlugin } from 'vite'
 import svgr from 'vite-plugin-svgr'
 import react from '@vitejs/plugin-react-swc'
+import { visualizer } from 'rollup-plugin-visualizer'
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [svgr(), react()],
+  plugins: [svgr(), react(), splitVendorChunkPlugin(), visualizer() as PluginOption],
 })

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -6,4 +6,25 @@ import { visualizer } from 'rollup-plugin-visualizer'
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [svgr(), react(), splitVendorChunkPlugin(), visualizer() as PluginOption],
+  build: {
+    sourcemap: true,
+    rollupOptions: {
+      output: {
+        manualChunks(id: string) {
+          if (id.includes('ethers')) {
+            return 'ethers'
+          }
+          if (id.includes('recharts')) {
+            return 'recharts'
+          }
+          if (id.includes('lodash')) {
+            return 'lodash'
+          }
+          if (id.includes('react-dom')) {
+            return 'react-dom'
+          }
+        },
+      },
+    },
+  },
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,12 +45,12 @@ importers:
         specifier: ^4.9.5
         version: 4.9.6
       ethers:
-        specifier: ^6.11.1
-        version: 6.11.1
+        specifier: 6.10.0
+        version: 6.10.0
     devDependencies:
       '@nomicfoundation/hardhat-ethers':
         specifier: ^3.0.5
-        version: 3.0.5(ethers@6.11.1)(hardhat@2.21.0)
+        version: 3.0.5(ethers@6.10.0)(hardhat@2.21.0)
       '@oasisprotocol/sapphire-contracts':
         specifier: ^0.2.7
         version: 0.2.7
@@ -59,10 +59,10 @@ importers:
         version: 2.19.4(hardhat@2.21.0)
       '@typechain/ethers-v6':
         specifier: ^0.5.1
-        version: 0.5.1(ethers@6.11.1)(typechain@8.3.2)(typescript@5.3.3)
+        version: 0.5.1(ethers@6.10.0)(typechain@8.3.2)(typescript@5.3.3)
       '@typechain/hardhat':
         specifier: ^9.1.0
-        version: 9.1.0(@typechain/ethers-v6@0.5.1)(ethers@6.11.1)(hardhat@2.21.0)(typechain@8.3.2)
+        version: 9.1.0(@typechain/ethers-v6@0.5.1)(ethers@6.10.0)(hardhat@2.21.0)(typechain@8.3.2)
       '@types/chai':
         specifier: ^4.3.11
         version: 4.3.12
@@ -118,8 +118,8 @@ importers:
         specifier: ^2.0.8
         version: 2.0.8
       ethers:
-        specifier: ^6.11.1
-        version: 6.11.1
+        specifier: 6.10.0
+        version: 6.10.0
       react:
         specifier: ^18.2.0
         version: 18.2.0
@@ -151,6 +151,9 @@ importers:
       '@vitejs/plugin-react-swc':
         specifier: ^3.5.0
         version: 3.6.0(vite@5.1.4)
+      rollup-plugin-visualizer:
+        specifier: ^5.12.0
+        version: 5.12.0
       typescript:
         specifier: ^5.2.2
         version: 5.3.3
@@ -170,9 +173,6 @@ packages:
 
   /@adraffy/ens-normalize@1.10.0:
     resolution: {integrity: sha512-nA9XHtlAkYfJxY7bce8DcN7eKxWWCWkU+1GR9d+U6MbNpfwQp8TI7vqOsBsMcHoT4mBu2kypKoSKnghEzOOq5Q==}
-
-  /@adraffy/ens-normalize@1.10.1:
-    resolution: {integrity: sha512-96Z2IP3mYmF1Xg2cDm8f1gWGf/HUVedQ3FMifV4kG/PQ4yEP51xDtRAEfhVNt5f/uzpNkZHwWQuUcu6D6K+Ekw==}
 
   /@ampproject/remapping@2.3.0:
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
@@ -1071,14 +1071,14 @@ packages:
       ethereum-cryptography: 0.1.3
     dev: true
 
-  /@nomicfoundation/hardhat-ethers@3.0.5(ethers@6.11.1)(hardhat@2.21.0):
+  /@nomicfoundation/hardhat-ethers@3.0.5(ethers@6.10.0)(hardhat@2.21.0):
     resolution: {integrity: sha512-RNFe8OtbZK6Ila9kIlHp0+S80/0Bu/3p41HUpaRIoHLm6X3WekTd83vob3rE54Duufu1edCiBDxspBzi2rxHHw==}
     peerDependencies:
       ethers: ^6.1.0
       hardhat: ^2.0.0
     dependencies:
       debug: 4.3.4(supports-color@8.1.1)
-      ethers: 6.11.1
+      ethers: 6.10.0
       hardhat: 2.21.0(ts-node@10.9.2)(typescript@5.3.3)
       lodash.isequal: 4.5.0
     transitivePeerDependencies:
@@ -1718,21 +1718,21 @@ packages:
     resolution: {integrity: sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==}
     dev: true
 
-  /@typechain/ethers-v6@0.5.1(ethers@6.11.1)(typechain@8.3.2)(typescript@5.3.3):
+  /@typechain/ethers-v6@0.5.1(ethers@6.10.0)(typechain@8.3.2)(typescript@5.3.3):
     resolution: {integrity: sha512-F+GklO8jBWlsaVV+9oHaPh5NJdd6rAKN4tklGfInX1Q7h0xPgVLP39Jl3eCulPB5qexI71ZFHwbljx4ZXNfouA==}
     peerDependencies:
       ethers: 6.x
       typechain: ^8.3.2
       typescript: '>=4.7.0'
     dependencies:
-      ethers: 6.11.1
+      ethers: 6.10.0
       lodash: 4.17.21
       ts-essentials: 7.0.3(typescript@5.3.3)
       typechain: 8.3.2(typescript@5.3.3)
       typescript: 5.3.3
     dev: true
 
-  /@typechain/hardhat@9.1.0(@typechain/ethers-v6@0.5.1)(ethers@6.11.1)(hardhat@2.21.0)(typechain@8.3.2):
+  /@typechain/hardhat@9.1.0(@typechain/ethers-v6@0.5.1)(ethers@6.10.0)(hardhat@2.21.0)(typechain@8.3.2):
     resolution: {integrity: sha512-mtaUlzLlkqTlfPwB3FORdejqBskSnh+Jl8AIJGjXNAQfRQ4ofHADPl1+oU7Z3pAJzmZbUXII8MhOLQltcHgKnA==}
     peerDependencies:
       '@typechain/ethers-v6': ^0.5.1
@@ -1740,8 +1740,8 @@ packages:
       hardhat: ^2.9.9
       typechain: ^8.3.2
     dependencies:
-      '@typechain/ethers-v6': 0.5.1(ethers@6.11.1)(typechain@8.3.2)(typescript@5.3.3)
-      ethers: 6.11.1
+      '@typechain/ethers-v6': 0.5.1(ethers@6.10.0)(typechain@8.3.2)(typescript@5.3.3)
+      ethers: 6.10.0
       fs-extra: 9.1.0
       hardhat: 2.21.0(ts-node@10.9.2)(typescript@5.3.3)
       typechain: 8.3.2(typescript@5.3.3)
@@ -2471,6 +2471,15 @@ packages:
       wrap-ansi: 7.0.0
     dev: true
 
+  /cliui@8.0.1:
+    resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
+    engines: {node: '>=12'}
+    dependencies:
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      wrap-ansi: 7.0.0
+    dev: true
+
   /clone@1.0.4:
     resolution: {integrity: sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==}
     engines: {node: '>=0.8'}
@@ -2747,6 +2756,11 @@ packages:
       es-define-property: 1.0.0
       es-errors: 1.3.0
       gopd: 1.0.1
+    dev: true
+
+  /define-lazy-prop@2.0.0:
+    resolution: {integrity: sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==}
+    engines: {node: '>=8'}
     dev: true
 
   /define-properties@1.2.1:
@@ -3168,21 +3182,6 @@ packages:
     engines: {node: '>=14.0.0'}
     dependencies:
       '@adraffy/ens-normalize': 1.10.0
-      '@noble/curves': 1.2.0
-      '@noble/hashes': 1.3.2
-      '@types/node': 18.15.13
-      aes-js: 4.0.0-beta.5
-      tslib: 2.4.0
-      ws: 8.5.0
-    transitivePeerDependencies:
-      - bufferutil
-      - utf-8-validate
-
-  /ethers@6.11.1:
-    resolution: {integrity: sha512-mxTAE6wqJQAbp5QAe/+o+rXOID7Nw91OZXvgpjDa1r4fAbq2Nu314oEZSbjoRLacuCzs7kUC3clEvkCQowffGg==}
-    engines: {node: '>=14.0.0'}
-    dependencies:
-      '@adraffy/ens-normalize': 1.10.1
       '@noble/curves': 1.2.0
       '@noble/hashes': 1.3.2
       '@types/node': 18.15.13
@@ -3870,6 +3869,12 @@ packages:
       has-tostringtag: 1.0.2
     dev: true
 
+  /is-docker@2.2.1:
+    resolution: {integrity: sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==}
+    engines: {node: '>=8'}
+    hasBin: true
+    dev: true
+
   /is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
     engines: {node: '>=0.10.0'}
@@ -3981,6 +3986,13 @@ packages:
     resolution: {integrity: sha512-qctsuLZmIQ0+vSSMfoVvyFe2+GSEvnmZ2ezTup1SBse9+twCCeial6EEi3Nc2KFcf6+qz2FBPnjXsk8xhKSaPQ==}
     dependencies:
       call-bind: 1.0.7
+    dev: true
+
+  /is-wsl@2.2.0:
+    resolution: {integrity: sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==}
+    engines: {node: '>=8'}
+    dependencies:
+      is-docker: 2.2.1
     dev: true
 
   /isarray@2.0.5:
@@ -4555,6 +4567,15 @@ packages:
       mimic-fn: 4.0.0
     dev: true
 
+  /open@8.4.2:
+    resolution: {integrity: sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==}
+    engines: {node: '>=12'}
+    dependencies:
+      define-lazy-prop: 2.0.0
+      is-docker: 2.2.1
+      is-wsl: 2.2.0
+    dev: true
+
   /optionator@0.9.3:
     resolution: {integrity: sha512-JjCoypp+jKn1ttEFExxhetCKeJt9zhAgAve5FXHixTvFDW/5aEktX9bufBKLRRMdU7bNtpLfcGu94B3cdEJgjg==}
     engines: {node: '>= 0.8.0'}
@@ -5052,6 +5073,22 @@ packages:
       bn.js: 5.2.1
     dev: true
 
+  /rollup-plugin-visualizer@5.12.0:
+    resolution: {integrity: sha512-8/NU9jXcHRs7Nnj07PF2o4gjxmm9lXIrZ8r175bT9dK8qoLlvKTwRMArRCMgpMGlq8CTLugRvEmyMeMXIU2pNQ==}
+    engines: {node: '>=14'}
+    hasBin: true
+    peerDependencies:
+      rollup: 2.x || 3.x || 4.x
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+    dependencies:
+      open: 8.4.2
+      picomatch: 2.3.1
+      source-map: 0.7.4
+      yargs: 17.7.2
+    dev: true
+
   /rollup@4.12.0:
     resolution: {integrity: sha512-wz66wn4t1OHIJw3+XU7mJJQV/2NAfw5OAk6G6Hoo3zcvz/XOfQ52Vgi+AN4Uxoxi0KBBwk2g8zPrTDA4btSB/Q==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
@@ -5312,6 +5349,11 @@ packages:
   /source-map@0.6.1:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
+    dev: true
+
+  /source-map@0.7.4:
+    resolution: {integrity: sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==}
+    engines: {node: '>= 8'}
     dev: true
 
   /spdx-correct@3.2.0:
@@ -6011,6 +6053,11 @@ packages:
     engines: {node: '>=10'}
     dev: true
 
+  /yargs-parser@21.1.1:
+    resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
+    engines: {node: '>=12'}
+    dev: true
+
   /yargs-unparser@2.0.0:
     resolution: {integrity: sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==}
     engines: {node: '>=10'}
@@ -6032,6 +6079,19 @@ packages:
       string-width: 4.2.3
       y18n: 5.0.8
       yargs-parser: 20.2.4
+    dev: true
+
+  /yargs@17.7.2:
+    resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
+    engines: {node: '>=12'}
+    dependencies:
+      cliui: 8.0.1
+      escalade: 3.1.2
+      get-caller-file: 2.0.5
+      require-directory: 2.1.1
+      string-width: 4.2.3
+      y18n: 5.0.8
+      yargs-parser: 21.1.1
     dev: true
 
   /yn@3.1.1:


### PR DESCRIPTION
## Description

- use exact version of `ethers` 6.10.0 due to `@oasisprotocol/sapphire-paratime` dependency
- Add `rollup-plugin-visualizer`, use `npx vite-bundle-visualizer` inside `frontend` folder, for report

## Resources

Previously:

```console
❯ npx vite-bundle-visualizer
vite v5.1.4 building for production...
✓ 1238 modules transformed.
dist/index.html                                                      0.47 kB │ gzip:   0.30 kB
dist/assets/figtree-latin-ext-wght-normal-Bptc-cl5.woff2            10.10 kB
dist/assets/roboto-mono-vietnamese-wght-normal-B7nCECYT.woff2       10.26 kB
dist/assets/roboto-mono-greek-wght-normal-C58MjUu-.woff2            14.09 kB
dist/assets/roboto-mono-cyrillic-wght-normal-CK9U7V71.woff2         18.60 kB
dist/assets/figtree-latin-wght-normal-tyJnQ6lj.woff2                20.08 kB
dist/assets/roboto-mono-latin-ext-wght-normal-BWJwKVm9.woff2        22.87 kB
dist/assets/roboto-mono-latin-wght-normal-DGRqvGGI.woff2            32.94 kB
dist/assets/roboto-mono-cyrillic-ext-wght-normal-DPu6aEAn.woff2     35.89 kB
dist/assets/index-f5ltzcoX.css                                      18.48 kB │ gzip:   4.33 kB
dist/assets/index-CKw_9xB2.js                                    1,240.81 kB │ gzip: 410.95 kB

(!) Some chunks are larger than 500 kB after minification. Consider:
- Using dynamic import() to code-split the application
- Use build.rollupOptions.output.manualChunks to improve chunking: https://rollupjs.org/configuration-options/#output-manualchunks
- Adjust chunk size limit for this warning via build.chunkSizeWarningLimit.
✓ built in 2.95s
```

![Screenshot_27-3-2024_14617_](https://github.com/oasisprotocol/dapp-votee/assets/9722540/6dde1831-b502-4e53-9aca-94faf02b5a51)

Current(all assets under default 500kb limit):

```console
❯ npx vite-bundle-visualizer
vite v5.1.4 building for production...
✓ 1123 modules transformed.
dist/index.html                                                    0.86 kB │ gzip:   0.39 kB
dist/assets/figtree-latin-ext-wght-normal-Bptc-cl5.woff2          10.10 kB
dist/assets/roboto-mono-vietnamese-wght-normal-B7nCECYT.woff2     10.26 kB
dist/assets/roboto-mono-greek-wght-normal-C58MjUu-.woff2          14.09 kB
dist/assets/roboto-mono-cyrillic-wght-normal-CK9U7V71.woff2       18.60 kB
dist/assets/figtree-latin-wght-normal-tyJnQ6lj.woff2              20.08 kB
dist/assets/roboto-mono-latin-ext-wght-normal-BWJwKVm9.woff2      22.87 kB
dist/assets/roboto-mono-latin-wght-normal-DGRqvGGI.woff2          32.94 kB
dist/assets/roboto-mono-cyrillic-ext-wght-normal-DPu6aEAn.woff2   35.89 kB
dist/assets/index-BzmJrU6M.css                                    18.52 kB │ gzip:   4.33 kB
dist/assets/lodash-ByOxUBs_.js                                    28.11 kB │ gzip:  11.56 kB │ map:   228.29 kB
dist/assets/index-awQyAFrF.js                                     47.58 kB │ gzip:  16.91 kB │ map:   129.14 kB
dist/assets/react-dom-Ddi3USIR.js                                167.92 kB │ gzip:  52.75 kB │ map:   504.61 kB
dist/assets/ethers-DN1VZNda.js                                   175.44 kB │ gzip:  51.72 kB │ map:   801.14 kB
dist/assets/recharts-DGNO4Vbe.js                                 216.23 kB │ gzip:  51.07 kB │ map:   857.16 kB
dist/assets/vendor-C7c7JVNO.js                                   386.25 kB │ gzip: 147.39 kB │ map: 1,674.81 kB
✓ built in 2.92s
```
![Screenshot_27-3-2024_14413_](https://github.com/oasisprotocol/dapp-votee/assets/9722540/ad1987da-04a0-4d7a-b069-f9e34da84e00)

