### PR TITLE
Show loading screen, after user confirms vote tx

### DIFF
--- a/frontend/src/pages/HomePage/index.tsx
+++ b/frontend/src/pages/HomePage/index.tsx
@@ -20,6 +20,7 @@ export const HomePage: FC = () => {
   const {
     state: { isConnected, account },
     vote,
+    getTransaction,
     canVoteOnPoll,
   } = useWeb3()
   const {
@@ -90,15 +91,16 @@ export const HomePage: FC = () => {
     setIsLoading(true)
 
     try {
-      setPageStatus('loading')
-
       const canVote = await handleCanVoteOnPoll()
       if (canVote === null) {
         setIsLoading(false)
         return
       }
 
-      await vote(selectedChoice)
+      const txResponse = (await vote(selectedChoice))!
+      setPageStatus('loading')
+      await getTransaction(txResponse.hash)
+
       setPreviousVoteForCurrentWallet(selectedChoice)
 
       setPageStatus('success')

--- a/frontend/src/providers/Web3Provider.tsx
+++ b/frontend/src/providers/Web3Provider.tsx
@@ -253,9 +253,7 @@ export const Web3ContextProvider: FC<PropsWithChildren> = ({ children }) => {
     unsignedTx.gasLimit = MAX_GAS_LIMIT
     unsignedTx.value = 0n
 
-    const txResponse = await signer.sendTransaction(unsignedTx).catch(handleKnownEthersErrors)
-
-    return await getTransaction(txResponse.hash)
+    return await signer.sendTransaction(unsignedTx).catch(handleKnownEthersErrors)
   }
 
   const getVoteCounts = async () => {


### PR DESCRIPTION
There seems to be a user experience issue when a user submits a voting transaction. The loading screen is displayed prematurely - before the actual submission of the transaction, while the user may still have a Web3 wallet extension window open. This can lead to confusion as the user might not be aware of the open wallet extension window.