### PR TITLE
Bump actions/deploy-pages to v4

### DIFF
--- a/.github/workflows/frontend-deploy.yml
+++ b/.github/workflows/frontend-deploy.yml
@@ -69,4 +69,4 @@ jobs:
           path: 'frontend/dist/'
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v3
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
`This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v3``