### PR TITLE
Bump actions/upload-pages-artifact to v3

### DIFF
--- a/.github/workflows/frontend-deploy.yml
+++ b/.github/workflows/frontend-deploy.yml
@@ -64,7 +64,7 @@ jobs:
             echo "::warning title=Invalid file permissions automatically fixed::$line"
           done
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v2
+        uses: actions/upload-pages-artifact@v3
         with:
           path: 'frontend/dist/'
       - name: Deploy to GitHub Pages


### PR DESCRIPTION
I forgot to bump main deploy action in prev PR.

We need `actions/upload-pages-artifact@v3` as it used upload-artifact v4  